### PR TITLE
Register models in Django admin and remove Group

### DIFF
--- a/airport/admin.py
+++ b/airport/admin.py
@@ -1,3 +1,25 @@
 from django.contrib import admin
+from django.contrib.auth.models import Group
 
-# Register your models here.
+from .models import (
+    Airplane,
+    Flight,
+    Crew,
+    Route,
+    Ticket,
+    Order,
+    Airport,
+    AirplaneType
+)
+
+
+admin.site.unregister(Group)
+
+admin.site.register(Airplane)
+admin.site.register(Flight)
+admin.site.register(Crew)
+admin.site.register(Route)
+admin.site.register(Ticket)
+admin.site.register(Order)
+admin.site.register(Airport)
+admin.site.register(AirplaneType)

--- a/user/admin.py
+++ b/user/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import User
+
+
+admin.site.register(User)


### PR DESCRIPTION
## Summary
- Unregistered `Group` from admin.
- Registered `Airplane`, `Flight`, `Crew`, `Route`, `Ticket`, `Order`, `Airport`, `AirplaneType` models.
- Registered custom `User` model.
