### PR TITLE
Improve API docs with Swagger and docstrings

### DIFF
--- a/airport/views/airplane.py
+++ b/airport/views/airplane.py
@@ -1,4 +1,6 @@
 from django.db.models import QuerySet
+from django.http import HttpResponse, HttpRequest
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import viewsets
 
 from airport.models import AirplaneType, Airplane
@@ -12,12 +14,22 @@ from airport.serializers.airplane import (
 
 
 class AirplaneTypeViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAdminOrIfAuthenticatedReadOnly,)
+    """
+    Manage airplane_types in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Read-only for authenticated users; full access for admins.
+    """
+    permission_classes = [IsAdminOrIfAuthenticatedReadOnly]
     queryset = AirplaneType.objects.all()
     serializer_class = AirplaneTypeSerializer
 
 
 class AirplaneViewSet(viewsets.ModelViewSet):
+    """
+    Manage airplanes in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Read-only for authenticated users; full access for admins.
+    """
     permission_classes = [IsAdminOrIfAuthenticatedReadOnly]
 
     def get_queryset(self) -> QuerySet:
@@ -38,3 +50,16 @@ class AirplaneViewSet(viewsets.ModelViewSet):
         elif self.action == "retrieve":
             serializer = AirplaneRetrieveSerializer
         return serializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="name",
+                type=str,
+                description="Filter by name (e.g., ?name=Mriya)",
+                required=False
+            )
+        ]
+    )
+    def list(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        return super().list(request, *args, **kwargs)

--- a/airport/views/airport.py
+++ b/airport/views/airport.py
@@ -1,4 +1,6 @@
 from django.db.models import QuerySet
+from django.http import HttpResponse, HttpRequest
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
 
 from airport.models import Airport
@@ -7,6 +9,11 @@ from airport.serializers.airport import AirportSerializer
 
 
 class AirportViewSet(viewsets.ModelViewSet):
+    """
+    Manage airports in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Read-only for authenticated users; full access for admins.
+    """
     permission_classes = [IsAdminOrIfAuthenticatedReadOnly]
     serializer_class = AirportSerializer
 
@@ -16,3 +23,16 @@ class AirportViewSet(viewsets.ModelViewSet):
         if airport_name:
             queryset = queryset.filter(name__icontains=airport_name)
         return queryset
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="name",
+                type=str,
+                description="Filter by name (e.g., ?name=Boryspil)",
+                required=False
+            )
+        ]
+    )
+    def list(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        return super().list(request, *args, **kwargs)

--- a/airport/views/crew.py
+++ b/airport/views/crew.py
@@ -1,4 +1,6 @@
 from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import viewsets
 
 from airport.models import Crew
@@ -7,6 +9,11 @@ from airport.serializers.crew import CrewSerializer
 
 
 class CrewViewSet(viewsets.ModelViewSet):
+    """
+    Manage crew in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Read-only for authenticated users; full access for admins.
+    """
     permission_classes = [IsAdminOrIfAuthenticatedReadOnly]
     serializer_class = CrewSerializer
 
@@ -24,3 +31,29 @@ class CrewViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(position__exact=position)
 
         return queryset
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="first_name",
+                type=str,
+                description="Filter by first_name (e.g., ?first_name=Andrii)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="last_name",
+                type=str,
+                description="Filter by last_name (e.g., ?last_name=Shevchenko)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="position",
+                type=str,
+                description="Filter by position",
+                required=False,
+                enum=["pilot", "attendant", "engineer"]
+            )
+        ]
+    )
+    def list(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        return super().list(request, *args, **kwargs)

--- a/airport/views/flight.py
+++ b/airport/views/flight.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
 from django.db.models import QuerySet, F, Count
+from django.http import HttpRequest, HttpResponse
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import viewsets
 
 from airport.models import Flight
@@ -16,6 +20,11 @@ from airport.serializers.flight import (
 
 
 class FlightViewSet(viewsets.ModelViewSet):
+    """
+    Manage flights in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Read-only for authenticated users; full access for admins.
+    """
     permission_classes = [IsAdminOrIfAuthenticatedReadOnly]
 
     def get_queryset(self) -> QuerySet:
@@ -76,3 +85,34 @@ class FlightViewSet(viewsets.ModelViewSet):
         elif self.action == "retrieve":
             serializer = FlightRetrieveSerializer
         return serializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="route",
+                type=int,
+                description="Filter by route_id (e.g., ?route_id=1)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="airplane",
+                type=int,
+                description="Filter by airplane_id (e.g., ?airplane_id=1)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="departure_time",
+                type=datetime,
+                description="Filter by departure_time (e.g., ?departure_time=2025-08-24)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="crew",
+                type={"type": "list", "items": {"type": "int"}},
+                description="Filter by crew_ids (e.g., ?crew_ids=1,2)",
+                required=False
+            )
+        ]
+    )
+    def list(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        return super().list(request, *args, **kwargs)

--- a/airport/views/order.py
+++ b/airport/views/order.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
 from django.db.models import QuerySet, Prefetch
+from django.http import HttpRequest, HttpResponse
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
@@ -13,6 +17,11 @@ from airport.serializers.order import (
 
 
 class OrderViewSet(viewsets.ModelViewSet):
+    """
+    Manage orders in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Authenticated users can only access their own orders.
+    """
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self) -> QuerySet:
@@ -59,3 +68,22 @@ class OrderViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer: OrderSerializer) -> None:
         serializer.save(user=self.request.user)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="flight",
+                type=int,
+                description="Filter by flight_id (e.g., ?flight_id=1)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="created_at",
+                type=datetime,
+                description="Filter by created_time (e.g., ?created_at=2025-08-2024)",
+                required=False
+            )
+        ]
+    )
+    def list(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        return super().list(request, *args, **kwargs)

--- a/airport/views/route.py
+++ b/airport/views/route.py
@@ -1,4 +1,6 @@
 from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponse
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import viewsets
 
 from airport.models import Route
@@ -11,6 +13,11 @@ from airport.serializers.route import (
 
 
 class RouteViewSet(viewsets.ModelViewSet):
+    """
+    Manage routes in the system.
+    Supports listing, retrieving, creating, updating, and deleting.
+    Read-only for authenticated users; full access for admins.
+    """
     permission_classes = [IsAdminOrIfAuthenticatedReadOnly]
 
     def get_queryset(self) -> QuerySet:
@@ -34,3 +41,22 @@ class RouteViewSet(viewsets.ModelViewSet):
         elif self.action == "retrieve":
             serializer = RouteRetrieveSerializer
         return serializer
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="source",
+                type=str,
+                description="Filter by source_name (e.g., ?source_name=Boryspil)",
+                required=False
+            ),
+            OpenApiParameter(
+                name="destination",
+                type=str,
+                description="Filter by destination_name (e.g., ?destination_name=Manchester)",
+                required=False
+            )
+        ]
+    )
+    def list(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        return super().list(request, *args, **kwargs)

--- a/airport_service/settings.py
+++ b/airport_service/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "debug_toolbar",
     "rest_framework",
+    "drf_spectacular",
     "airport",
     "user"
 ]
@@ -161,9 +162,24 @@ REST_FRAMEWORK = {
         "anon": "100/day",
         "user": "1000/day"
     },
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 5,
     "MAX_PAGE_SIZE": 50,
+}
+
+# Settings to improve Swagger documentation display
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Airport Service API",
+    "DESCRIPTION": "Order tickets for flights",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "SWAGGER_UI_SETTINGS": {
+        "deepLinking": True,
+        "defaultModelRendering": "model",
+        "defaultModelsExpandDepth": 2,
+        "defaultModelExpandDepth": 2,
+    }
 }
 
 # JWT settings

--- a/airport_service/urls.py
+++ b/airport_service/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from airport_service import settings
 
@@ -25,5 +26,11 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("__debug__/", include("debug_toolbar.urls")),
     path("api/airport/", include("airport.urls", namespace="airport")),
-    path("api/user/", include("user.urls", namespace="user"))
+    path("api/user/", include("user.urls", namespace="user")),
+    path("api/doc/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/doc/swagger/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui"
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/user/views.py
+++ b/user/views.py
@@ -9,11 +9,19 @@ User = get_user_model()
 
 
 class CreateUserView(generics.CreateAPIView):
+    """
+    Create a new user account.
+    Accessible without authentication.
+    """
     permission_classes = [AllowAny]
     serializer_class = UserSerializer
 
 
 class ManageUserView(generics.RetrieveUpdateAPIView):
+    """
+    Retrieve or update the authenticated user's profile.
+    Only accessible to authenticated users.
+    """
     permission_classes = [IsAuthenticated]
     serializer_class = UserSerializer
 


### PR DESCRIPTION
## Summary

- Added **drf-spectacular** support for API documentation.
- Added **docstrings** for all airport and user views.
- Extended schema using `@extend_schema` and `OpenApiParameter` for query parameters.
- Added API doc URLs.
